### PR TITLE
Sync upstream with the v0.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ report benchmark results against snap-based components.
 
 ## Usage
 
-`kube-bench` is designed to run against master and worker nodes. There are
-two methods for using the configuration from this repository with `kube-bench`:
-
-### Charm action
-
 The [layer-cis-benchmark][] base layer is included in in `kubernetes-master`,
 `kubernetes-worker`, and `etcd` charms. This layer provides a `cis-benchmark`
 action to facilitate the installation and execution of `kube-bench`.
@@ -20,36 +15,6 @@ action to facilitate the installation and execution of `kube-bench`.
 By default, the action will use the contents of this repository as the source
 of the `kube-bench` configuration. Simply run the `cis-benchmark` action on
 desired charms as described in the [layer README][layer-cis-benchmark-readme].
-
-### Manual
-
-Follow the `kube-bench` installation procedure from the [kube-bench][] website.
-Once installed, clone this repository:
-
-```bash
-git clone https://github.com/charmed-kubernetes/kube-bench-config.git
-```
-
-Specify the configuration directory, version, and component for each node you
-wish to test:
-
-#### kubernetes-master
-
-```bash
-kube-bench -D /path/to/kube-bench-config --version 1.13-snap-k8s master
-```
-
-#### kubernetes-worker
-
-```bash
-kube-bench -D /path/to/kube-bench-config --version 1.13-snap-k8s node
-```
-
-#### etcd
-
-```bash
-kube-bench -D /path/to/kube-bench-config --version 1.13-snap-etcd master
-```
 
 <!-- LINKS -->
 

--- a/cis-1.5/controlplane.yaml
+++ b/cis-1.5/controlplane.yaml
@@ -1,0 +1,35 @@
+---
+controls:
+version: 1.5
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Not Scored)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Scored)"
+        type: "manual"
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: true
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Not Scored)"
+        type: "manual"
+        remediation: |
+          Consider modification of the audit policy in use on the cluster to include these items, at a
+          minimum.
+        scored: false

--- a/cis-1.5/master.yaml
+++ b/cis-1.5/master.yaml
@@ -6,48 +6,17 @@ text: "Master Node Security Configuration"
 type: "master"
 groups:
   - id: 1.1
-    text: "Master Node Configuration Files "
+    text: "Master Node Configuration Files"
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %a $apiserverconf; fi'"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
@@ -73,44 +42,13 @@ groups:
 
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %a $controllermanagerconf; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -136,44 +74,13 @@ groups:
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -199,45 +106,13 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
-        type: "skip"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -248,7 +123,6 @@ groups:
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -264,7 +138,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Not Scored)"
-        audit: "stat -c %a <path/to/cni/files>"
+        audit: "stat -c permissions=%a <path/to/cni/files>"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -284,26 +158,25 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %a
-        type: "skip"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
               set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the below command:
-          ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
-        type: "skip"
         tests:
           test_items:
             - flag: "etcd:etcd"
@@ -318,45 +191,13 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %a /etc/kubernetes/admin.conf; fi'"
-        type: "skip"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -365,9 +206,8 @@ groups:
         scored: true
 
       - id: 1.1.14
-        text: "Ensure that the admin.conf file ownership is set to root:root (Scored) "
+        text: "Ensure that the admin.conf file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
-        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -383,45 +223,13 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e /etc/kubernetes/scheduler.conf; then stat -c %a /etc/kubernetes/scheduler.conf; fi'"
-        type: "skip"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/scheduler.conf; then stat -c permissions=%a /etc/kubernetes/scheduler.conf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -432,7 +240,6 @@ groups:
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/scheduler.conf; then stat -c %U:%G /etc/kubernetes/scheduler.conf; fi'"
-        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -448,45 +255,13 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
-        audit: "/bin/sh -c 'if test -e /etc/kubernetes/controller-manager.conf; then stat -c %a /etc/kubernetes/controller-manager.conf; fi'"
-        type: "skip"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/controller-manager.conf; then stat -c permissions=%a /etc/kubernetes/controller-manager.conf; fi'"
         tests:
-          bin_op: or
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -497,7 +272,6 @@ groups:
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/controller-manager.conf; then stat -c %U:%G /etc/kubernetes/controller-manager.conf; fi'"
-        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -513,32 +287,32 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
-        audit: "ls -laR /root/cdk/"
+        audit: "ls -laR /etc/kubernetes/pki/"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chown -R root:root /root/cdk/
+          chown -R root:root /etc/kubernetes/pki/
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
-        audit: "stat -c %n\ %a /root/cdk/*.crt"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored)"
+        audit: "stat -c %n\ %a /etc/kubernetes/pki/*.crt"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /root/cdk/*.crt
+          chmod -R 644 /etc/kubernetes/pki/*.crt
         scored: true
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-        audit: "stat -c %n\ %a /root/cdk/*.key"
+        audit: "stat -c %n\ %a /etc/kubernetes/pki/*.key"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /root/cdk/*.key
+          chmod -R 600 /etc/kubernetes/pki/*.key
         scored: true
 
   - id: 1.2
@@ -765,12 +539,12 @@ groups:
         tests:
           bin_op: or
           test_items:
-            - flag: "--enable-admission-plugins"
+            - flag: "--disable-admission-plugins"
               compare:
-                op: has
+                op: nothave
                 value: "ServiceAccount"
               set: true
-            - flag: "--enable-admission-plugins"
+            - flag: "--disable-admission-plugins"
               set: false
         remediation: |
           Follow the documentation and create ServiceAccount objects as per your environment.
@@ -864,7 +638,7 @@ groups:
         scored: true
 
       - id: 1.2.20
-        text: "Ensure that the --secure-port argument is not set to 0 (Scored) "
+        text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -1015,7 +789,7 @@ groups:
         scored: true
 
       - id: 1.2.29
-        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored) "
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: and
@@ -1246,7 +1020,7 @@ groups:
         scored: true
 
       - id: 1.4.2
-        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Scored) "
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Scored)"
         audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
         tests:
           bin_op: or

--- a/cis-1.5/master.yaml
+++ b/cis-1.5/master.yaml
@@ -107,6 +107,7 @@ groups:
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -123,6 +124,7 @@ groups:
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -159,6 +161,7 @@ groups:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -177,6 +180,7 @@ groups:
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        type: "skip"
         tests:
           test_items:
             - flag: "etcd:etcd"
@@ -192,6 +196,7 @@ groups:
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -208,6 +213,7 @@ groups:
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -224,6 +230,7 @@ groups:
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/scheduler.conf; then stat -c permissions=%a /etc/kubernetes/scheduler.conf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -240,6 +247,7 @@ groups:
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/scheduler.conf; then stat -c %U:%G /etc/kubernetes/scheduler.conf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -256,6 +264,7 @@ groups:
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/controller-manager.conf; then stat -c permissions=%a /etc/kubernetes/controller-manager.conf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -272,6 +281,7 @@ groups:
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/controller-manager.conf; then stat -c %U:%G /etc/kubernetes/controller-manager.conf; fi'"
+        type: "skip"
         tests:
           test_items:
             - flag: "root:root"
@@ -287,32 +297,32 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
-        audit: "ls -laR /etc/kubernetes/pki/"
+        audit: "ls -laR /root/cdk/"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /root/cdk/
         scored: true
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored)"
-        audit: "stat -c %n\ %a /etc/kubernetes/pki/*.crt"
+        audit: "stat -c %n\ %a /root/cdk/*.crt"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          chmod -R 644 /root/cdk/*.crt
         scored: true
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-        audit: "stat -c %n\ %a /etc/kubernetes/pki/*.key"
+        audit: "stat -c %n\ %a /root/cdk/*.key"
         type: "manual"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          chmod -R 600 /root/cdk/*.key
         scored: true
 
   - id: 1.2

--- a/cis-1.5/node.yaml
+++ b/cis-1.5/node.yaml
@@ -109,9 +109,7 @@ groups:
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
         audit: |
           CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if [[ -z $CAFILE ]]; then
-            CAFILE=$kubeletcafile
-          fi
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:
           test_items:

--- a/cis-1.5/node.yaml
+++ b/cis-1.5/node.yaml
@@ -10,45 +10,14 @@ groups:
     checks:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %a $kubeletsvc; fi'' '
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
+              set: true
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
-          bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -70,49 +39,18 @@ groups:
 
       - id: 4.1.3
         text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive (Scored)"
-        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %a $proxykubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
+              set: true
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
-          bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
-          chmod 644 $proykubeconfig
+          chmod 644 $proxykubeconfig
         scored: true
 
       - id: 4.1.4
@@ -129,45 +67,14 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
+              set: true
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
-          bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -200,7 +107,12 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
-        audit: '/bin/sh -c ''if test -e $kubeletcafile; then stat -c %U:%G $kubeletcafile; fi'' '
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if [[ -z $CAFILE ]]; then
+            CAFILE=$kubeletcafile
+          fi
+          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:
           test_items:
             - flag: root:root
@@ -215,47 +127,16 @@ groups:
 
       - id: 4.1.9
         text: "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
-        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'' '
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               set: true
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-            - flag: "640"
-              set: true
-              compare:
-                op: eq
-                value: "640"
-            - flag: "600"
-              set: true
-              compare:
-                op: eq
-                value: "600"
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
-          bin_op: or
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 644 $kubeletconf
         scored: true
 
@@ -267,7 +148,7 @@ groups:
             - flag: root:root
               set: true
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
 
@@ -417,7 +298,7 @@ groups:
         scored: true
 
       - id: 4.2.7
-        text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored) "
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:

--- a/cis-1.5/policies.yaml
+++ b/cis-1.5/policies.yaml
@@ -1,0 +1,239 @@
+---
+controls:
+version: 1.5
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Not Scored)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Not Scored)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Not Scored)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Scored)"
+        type: "manual"
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: true
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Not Scored)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Policies"
+    checks:
+      - id: 5.2.1
+        text: "Minimize the admission of privileged containers (Not Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that
+          the .spec.privileged field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostPID field is omitted or set to false.
+        scored: true
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostIPC field is omitted or set to false.
+        scored: true
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host network namespace (Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostNetwork field is omitted or set to false.
+        scored: true
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.allowPrivilegeEscalation field is omitted or set to false.
+        scored: true
+
+      - id: 5.2.6
+        text: "Minimize the admission of root containers (Not Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of
+          UIDs not including 0.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of containers with the NET_RAW capability (Not Scored)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with added capabilities (Not Scored)"
+        type: "manual"
+        remediation: |
+          Ensure that allowedCapabilities is not present in PSPs for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with capabilities assigned (Not Scored)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications runnning on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports Network Policies (Not Scored)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have Network Policies defined (Scored)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: true
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using secrets as files over secrets as environment variables (Not Scored)"
+        type: "manual"
+        remediation: |
+          if possible, rewrite application code to read secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Not Scored)"
+        type: "manual"
+        remediation: |
+          Refer to the secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.6
+    text: "General Policies"
+    checks:
+      - id: 5.6.1
+        text: "Create administrative boundaries between resources using namespaces (Not Scored)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.6.2
+        text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Not Scored)"
+        type: "manual"
+        remediation: |
+          Seccomp is an alpha feature currently. By default, all alpha features are disabled. So, you
+          would need to enable alpha features in the apiserver by passing "--feature-
+          gates=AllAlpha=true" argument.
+          Edit the /etc/kubernetes/apiserver file on the master node and set the KUBE_API_ARGS
+          parameter to "--feature-gates=AllAlpha=true"
+          KUBE_API_ARGS="--feature-gates=AllAlpha=true"
+          Based on your system, restart the kube-apiserver service. For example:
+          systemctl restart kube-apiserver.service
+          Use annotations to enable the docker/default seccomp profile in your pod definitions. An
+          example is as below:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: trustworthy-pod
+            annotations:
+              seccomp.security.alpha.kubernetes.io/pod: docker/default
+          spec:
+            containers:
+              - name: trustworthy-container
+                image: sotrustworthy:latest
+        scored: false
+
+      - id: 5.6.3
+        text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply security contexts to your pods. For a
+          suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.6.4
+        text: "The default namespace should not be used (Scored)"
+        type: "manual"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: true

--- a/config.yaml
+++ b/config.yaml
@@ -27,8 +27,10 @@ master:
       - "apiserver"
     confs:
       - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/manifests/kube-apiserver.yml
       - /etc/kubernetes/manifests/kube-apiserver.manifest
       - /var/snap/kube-apiserver/current/args
+      - /var/snap/microk8s/current/args/kube-apiserver
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
@@ -39,8 +41,10 @@ master:
       - "scheduler"
     confs:
       - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/manifests/kube-scheduler.yml
       - /etc/kubernetes/manifests/kube-scheduler.manifest
       - /var/snap/kube-scheduler/current/args
+      - /var/snap/microk8s/current/args/kube-scheduler
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
@@ -52,8 +56,10 @@ master:
       - "controller-manager"
     confs:
       - /etc/kubernetes/manifests/kube-controller-manager.yaml
+      - /etc/kubernetes/manifests/kube-controller-manager.yml
       - /etc/kubernetes/manifests/kube-controller-manager.manifest
       - /var/snap/kube-controller-manager/current/args
+      - /var/snap/microk8s/current/args/kube-controller-manager
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
@@ -62,9 +68,12 @@ master:
       - "etcd"
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.yml
       - /etc/kubernetes/manifests/etcd.manifest
       - /etc/etcd/etcd.conf
       - /var/snap/etcd/common/etcd.conf.yml
+      - /var/snap/etcd/common/etcd.conf.yaml
+      - /var/snap/microk8s/current/args/etcd
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
   flanneld:
@@ -88,6 +97,7 @@ node:
       - "/etc/kubernetes/pki/ca.crt"
       - "/etc/kubernetes/certs/ca.crt"
       - "/etc/kubernetes/cert/ca.pem"
+      - "/var/snap/microk8s/current/certs/ca.crt"
     svc:
       # These paths must also be included
       #  in the 'confs' property below
@@ -95,6 +105,7 @@ node:
       - "/etc/systemd/system/kubelet.service"
       - "/lib/systemd/system/kubelet.service"
       - "/etc/systemd/system/snap.kubelet.daemon.service"
+      - "/etc/systemd/system/snap.microk8s.daemon-kubelet.service"
     bins:
       - "hyperkube kubelet"
       - "kubelet"
@@ -102,13 +113,17 @@ node:
       - "/etc/kubernetes/kubelet.conf"
       - "/var/lib/kubelet/kubeconfig"
       - "/etc/kubernetes/kubelet-kubeconfig"
+      - "/var/snap/microk8s/current/credentials/kubelet.config"
     confs:
       - "/var/lib/kubelet/config.yaml"
+      - "/var/lib/kubelet/config.yml"
       - "/etc/kubernetes/kubelet/kubelet-config.json"
       - "/home/kubernetes/kubelet-config.yaml"
+      - "/home/kubernetes/kubelet-config.yml"
       - "/etc/default/kubelet"
       - "/var/lib/kubelet/kubeconfig"
       - "/var/snap/kubelet/current/args"
+      - "/var/snap/microk8s/current/args/kubelet"
       ## Due to the fact that the kubelet might be configured
       ## without a kubelet-config file, we use a work-around
       ## of pointing to the systemd service file (which can also
@@ -118,6 +133,7 @@ node:
       - "/etc/systemd/system/kubelet.service"
       - "/lib/systemd/system/kubelet.service"
       - "/etc/systemd/system/snap.kubelet.daemon.service"
+      - "/etc/systemd/system/snap.microk8s.daemon-kubelet.service"
     defaultconf: "/var/lib/kubelet/config.yaml"
     defaultsvc: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
     defaultkubeconfig: "/etc/kubernetes/kubelet.conf"
@@ -133,12 +149,16 @@ node:
     confs:
       - /etc/kubernetes/proxy
       - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+      - /etc/kubernetes/addons/kube-proxy-daemonset.yml
       - /var/snap/kube-proxy/current/args
+      - /var/snap/microk8s/current/args/kube-proxy
     kubeconfig:
       - "/etc/kubernetes/kubelet-kubeconfig"
       - "/var/lib/kubelet/kubeconfig"
+      - "/var/snap/microk8s/current/credentials/proxy.config"
     svc:
       - "/lib/systemd/system/kube-proxy.service"
+      - "/etc/systemd/system/snap.microk8s.daemon-proxy.service"
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     defaultkubeconfig: "/etc/kubernetes/proxy.conf"
 
@@ -151,9 +171,12 @@ etcd:
       - "etcd"
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.yml
       - /etc/kubernetes/manifests/etcd.manifest
       - /etc/etcd/etcd.conf
       - /var/snap/etcd/common/etcd.conf.yml
+      - /var/snap/etcd/common/etcd.conf.yaml
+      - /var/snap/microk8s/current/args/etcd
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 controlplane:
@@ -162,6 +185,8 @@ controlplane:
 policies:
   components: []
 
+managedservices:
+  components: []
 
 version_mapping:
   "1.11": "cis-1.3"
@@ -171,6 +196,7 @@ version_mapping:
   "1.15": "cis-1.5"
   "1.16": "cis-1.5"
   "1.17": "cis-1.5"
+  "gke-1.0": "gke-1.0"
   "ocp-3.10": "rh-0.7"
   "ocp-3.11": "rh-0.7"
   "1.13-snap-etcd": "cis-1.5"


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1887693

Update our configs to match the [v0.3.1 upstream release](https://github.com/aquasecurity/kube-bench/tree/v0.3.1).  Also tweak the readme as we don't expect people to consume this repo directly -- instead, they should be using the `cis-benchmark` action on appropriate charms.